### PR TITLE
Fix hex data display, and improve portability

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -624,11 +624,11 @@ static void check_avoid_default_addr_size(struct check *c, struct node *dt,
 	if (!reg && !ranges)
 		return;
 
-	if ((node->parent->addr_cells == -1))
+	if (node->parent->addr_cells == -1)
 		FAIL(c, "Relying on default #address-cells value for %s",
 		     node->fullpath);
 
-	if ((node->parent->size_cells == -1))
+	if (node->parent->size_cells == -1)
 		FAIL(c, "Relying on default #size-cells value for %s",
 		     node->fullpath);
 }

--- a/fdtdump.c
+++ b/fdtdump.c
@@ -22,7 +22,7 @@
 static const char *tagname(uint32_t tag)
 {
 	static const char * const names[] = {
-#define TN(t) [t] #t
+#define TN(t) [t] = #t
 		TN(FDT_BEGIN_NODE),
 		TN(FDT_END_NODE),
 		TN(FDT_PROP),

--- a/util.c
+++ b/util.c
@@ -376,7 +376,7 @@ void utilfdt_print_data(const char *data, int len)
 
 		printf(" = <");
 		for (i = 0; i < len; i += 4)
-			printf("0x%08x%s", fdt32_to_cpu(cell[i]),
+			printf("0x%08x%s", fdt32_to_cpu(cell[i/4]),
 			       i < (len - 4) ? " " : "");
 		printf(">");
 	} else {


### PR DESCRIPTION
1) When displaying hex data, utilfdt_print_data indexes a uint32_t
pointer with a byte counter incremented in fours, resulting in
incorrect output.

2) Remove the double parentheses around two comparisons in checks.c,
and put an explicit "=" in the TN() macro in accordance with c99.
