### PR TITLE
dtc: Fix uninitialized value in local fixup generation

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -523,6 +523,7 @@ static void fixup_phandle_references(struct check *c, struct node *dt,
 			fe->prop = prop;
 			fe->offset = m->offset;
 			fe->next = NULL;
+			fe->local_fixup_generated = false;
 
 			/* append it to the local fixups */
 			fep = &dt->local_fixups;


### PR DESCRIPTION
The `local_fixup_generated` member of `struct fixup_entry` was not initialized on structure creation, causing fixups to randomly be left out of the compiled overlay. This generally manifested itself with kernel messages like

```
could not find pctldev for node /ocp/interrupt-controller@48200000, deferring probe
```

as the kernel tried to follow a pinctrl phandle and instead got whichever one happened to have the same ID as the overlay used internally (before fixups).

This bug has apparently been here for a year and a half, shows up prominently in `valgrind`, and affects functionality of at least one cape overlay currently shipped in the official Debian image (`BB-BONE-CRYPTO-00A0.dtbo`).
